### PR TITLE
fix for Istanbul

### DIFF
--- a/run.js
+++ b/run.js
@@ -311,7 +311,7 @@ function getForm(onUnrecognized, onComplete) {
 	);
 
     function getScopeOptionValue(body) {
-        var regex = new RegExp("<option value=\"([a-f0-9]+)\">" + scopeName + "</option>");
+        var regex = new RegExp("<option.*value=\"([a-f0-9]+)\">" + scopeName + "</option>");
         var match = body.match(regex);
         if (match) return match[1];
 


### PR DESCRIPTION
when looking at the source code of the sys.scripts.do form in Istanbul, the <option ...> tags now can have the additional attribute "selected" added...therefore the Regex is not capable of recognizing